### PR TITLE
(refactor)app: run the benchmark for 300s

### DIFF
--- a/App/nginx-bench.yaml
+++ b/App/nginx-bench.yaml
@@ -23,7 +23,7 @@ spec:
           - name: NGINX_PORT_NUM
             value: "80"
           - name: BENCHMARK_DURATION
-            value: "60"
+            value: "300"
         image: devth/alpine-bench
         imagePullPolicy: Always
         name: nginx-bench


### PR DESCRIPTION
- Allow for a long enough benchmark run to obtain stable numbers and also execute chaos. 

Signed-off-by: ksatchit <karthik.s@mayadata.io>